### PR TITLE
Fixes toObject call on Models that have Models/Collections as an attribute

### DIFF
--- a/source/src/js/Lavaca/util/Cache.js
+++ b/source/src/js/Lavaca/util/Cache.js
@@ -97,7 +97,7 @@ ns.Cache = Disposable.extend({
   toObject: function() {
     var result = {};
     this.each(function(prop, value) {
-      result[prop] = value;
+      result[prop] = typeof value.toObject === "function" ? value.toObject() : value;
     });
     return result;
   },


### PR DESCRIPTION
If a Model has a Model/Collection as one of it's attributes, this
will ensure that when toObject is called on the parent Model, the child
Model/Collection will also have it's toObject function called.
