### PR TITLE
DateUtils can stringify a date test fails in time zones that are ahead of UTC.

### DIFF
--- a/source/src/js/Lavaca/util/DateUtils.js
+++ b/source/src/js/Lavaca/util/DateUtils.js
@@ -443,9 +443,9 @@ ns.fn = {
     },
     o: function(date) {
       var z = date.getTimezoneOffset(),
-          sign = z < 0 ? '-' : '+',
+          sign = z > 0 ? '-' : '+',
           m = z % 60,
-          h = (z - m) / 60;
+          h = Math.abs((z - m) / 60);
       return sign + _pad(h, 2) + ':' + _pad(Math.abs(m), 2);
     }
   }

--- a/source/test/unit/Lavaca.util.DateUtils.js
+++ b/source/test/unit/Lavaca.util.DateUtils.js
@@ -1,4 +1,4 @@
-(function(ArrayUtils) { 
+(function(ArrayUtils) {
 
 function _padLeft(v, count, c) {
   v = v.toString();
@@ -25,7 +25,7 @@ describe('DateUtils', function() {
         off = date.getTimezoneOffset(),
         offH = Math.floor(Math.abs(off) / 60),
         offM = Math.floor(Math.abs(off) % 60),
-        offSign = off < 0 ? '-' : '+',
+        offSign = off > 0 ? '-' : '+',
         out = _padLeft(y, 4) + '-' + _padLeft(M, 2) + '-' + _padLeft(d, 2) + 'T' + _padLeft(h, 2) + ':' + _padLeft(m, 2) + ':' + _padLeft(s, 2) + '.' + _padLeft(ms, 3) + offSign + _padLeft(offH, 2) + ':' + _padLeft(offM, 2);
     expect(Lavaca.util.DateUtils.stringify(date, 'yyyy-MM-ddTHH:mm:ss.fffzzz')).toEqual(out);
   });


### PR DESCRIPTION
![Screenshot_2013-01-02_19_03](https://f.cloud.github.com/assets/18167/38062/0e8e3718-54cc-11e2-9d6a-a96974aacad5.png)

When the time zone is ahead of UTC/GMT the returned value for Date.getTimezoneOffset will be negative. The previous test inverted the sign, and as the sign is being set on it's own the hour value should always be an absolute value.

https://developer.mozilla.org/en-US/docs/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
