### PR TITLE
Add more configuration for how links are opened

### DIFF
--- a/src/www/js/lavaca/mvc/Application.js
+++ b/src/www/js/lavaca/mvc/Application.js
@@ -116,9 +116,18 @@ define(function(require) {
       }
       if (rel === 'back') {
         History.back();
+      // Animate backwards when these links are tapped
+      } else if (rel === 'force-back' && url) {
+        History.isRoutingBack = true;
+        this.router.exec(url, null, null).always(function() {
+          History.isRoutingBack = false;
+        });
       } else if (isExternal || rel === 'nofollow' || target === '_blank') {
         e.stopPropagation();
         new ChildBrowser().showWebPage(url);
+      // Open using the system browser, can be Google Maps/Safari etc...
+      } else if (target === '_system') {
+        window.open(url, target);
       } else if (rel === 'cancel') {
         this.viewManager.dismiss(e.currentTarget);
       } else if (url) {


### PR DESCRIPTION
These are some configuration points I've added to the apps I've built with Lavaca. 
Thinking they might be useful for others as well.
- Cordova got it built-in that target="_system" will open with the system
  browser, meaning that it can open a link with any other application
  installed if it's registered for that handler. Or just opening
  mobile Safari or the Android Browser if needed.
- rel="force-back" follows the link normally but animates it with the
  back animation.
