### PR TITLE
Make the example attribute in configuration be apiRoot

### DIFF
--- a/src/www/configs/local.json
+++ b/src/www/configs/local.json
@@ -1,3 +1,3 @@
 {
-  "example": "value - local"
+  "apiRoot": ""
 }

--- a/src/www/configs/production.json
+++ b/src/www/configs/production.json
@@ -1,3 +1,3 @@
 {
-  "example": "value - production"
+  "apiRoot": ""
 }

--- a/src/www/configs/staging.json
+++ b/src/www/configs/staging.json
@@ -1,3 +1,3 @@
 {
-  "example": "value - staging"
+  "apiRoot": ""
 }

--- a/src/www/js/lavaca/mvc/Model.js
+++ b/src/www/js/lavaca/mvc/Model.js
@@ -408,7 +408,7 @@ define(function(require) {
       this.trigger('fetchError', {response: response});
     },
     /**
-     * Loads the data for this model from the server and only apply to this model attributes (Note: Does not clear the model first)
+     * Loads the data for this model from the server and only apply to this model attributes (Note: Does not clear the model first) (Note: The url is prefixed with your configured apiRoot)
      * @method fetch
      *
      * @event fetchSuccess


### PR DESCRIPTION
apiRoot is used in fetch on model and collection but it isn't
explicitly declared on the fetch method, just on a method called
inside of fetch.

When I start a new project I keep looking around for this in my previous one, so it would be nicer if it was available as a standard value.
